### PR TITLE
高階関数のサンプルコードが書籍と表記が異なるため修正

### DIFF
--- a/03-fp/03-first-class/greeter.js
+++ b/03-fp/03-first-class/greeter.js
@@ -3,7 +3,7 @@ const greeter = (target) => {
     console.log(`Hi, ${target}!`);
   };
 
-  return sayHello();
+  return sayHello;
 };
 
 const greet = greeter('Jun');


### PR DESCRIPTION
書籍にも書いてありますが、`sayHello()`とした場合に関数の結果を返してしまうため`greet();`が失敗します。
